### PR TITLE
Fix W27C512 erasure bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .vscode/ipch
 
 .secrets
+.DS_Store

--- a/src/eprom.cpp
+++ b/src/eprom.cpp
@@ -56,16 +56,16 @@ void eprom_check_chip_id(firestarter_handle_t* handle) {
 }
 
 void eprom_internal_erase(firestarter_handle_t* handle) {
-    handle->firestarter_set_control_register(handle, REGULATOR, 1);
+    handle->firestarter_set_control_register(handle, REGULATOR, 1); //Enable regulator without dropping resistor
     delay(100);
     handle->firestarter_set_address(handle, 0x0000);
-    handle->firestarter_set_control_register(handle, A9_VPP_ENABLE | VPE_ENABLE | VPE_TO_VPP, 1);
+    handle->firestarter_set_control_register(handle, A9_VPP_ENABLE | VPE_ENABLE, 1); //Erase with VPE - assumes VPE_TO_VPP isn't set and left active previously
     delay(100);
     set_control_pin(CHIP_ENABLE, 0);
     delayMicroseconds(handle->pulse_delay);
     set_control_pin(CHIP_ENABLE, 1);
 
-    handle->firestarter_set_control_register(handle, REGULATOR | A9_VPP_ENABLE | VPE_ENABLE | VPE_TO_VPP, 0);
+    handle->firestarter_set_control_register(handle, REGULATOR | A9_VPP_ENABLE | VPE_ENABLE, 0);
 }
 
 void eprom_erase(firestarter_handle_t* handle) {


### PR DESCRIPTION
VPE_TO_VPP removed from erasure function to erase at VPE (14V) instead of VPP (12V).