### PR TITLE
Manual revision 2 mod configuration

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -15,6 +15,7 @@
 
 // #define POWER_THROUGH_ADDRESS_LINES
 #define HARDWARE_REVISION
+// #define MANUAL_REV_2
 // #define SERIAL_DEBUG 
 // #define DEBUG_ADDRESS
 

--- a/src/uno_rurp_shield.cpp
+++ b/src/uno_rurp_shield.cpp
@@ -123,6 +123,9 @@ void rurp_set_data_as_input() {
 uint8_t map_ctrl_reg_to_hardware_revision(uint16_t data) {
     uint8_t ctrl_reg = 0;
     int hw = rurp_get_hardware_revision();
+    #ifdef MANUAL_REV_2
+    hw = REVISION_2;
+    #endif
     switch (hw)
     {
     case REVISISION_2:


### PR DESCRIPTION
I'd like to give Rev1 owners the option to modify the board (cut A16 from socket pin 2, cut A18 from pin 1, and connect to A18 to pin 2) and set MANUAL_REV_2 in config.h to enable programming up to 4 Mbit 12/14V ROMs. 

This was the least intrusive way I could think of.  