### PR TITLE
Don't set address while serial is on

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -34,9 +34,7 @@ void configure_memory(firestarter_handle_t* handle) {
     handle->firestarter_set_control_register = memory_set_control_register;
     handle->firestarter_get_control_register = memory_get_control_register;
     handle->response_code = RESPONSE_CODE_OK;
-#ifdef POWER_THROUGH_ADDRESS_LINES
-    memory_set_address(handle, 0);
-#endif
+
     if (handle->mem_type == TYPE_EPROM) {
         configure_eprom(handle);
         return;


### PR DESCRIPTION
Setting memory address in configure_memory while serial is still on isn't needed and inadvertently puts 0x03 into the control register which gets reused and causes bad reads. 

Removing it solves the issue. 

Note for future: I assume the bug doesn't show for configure_eprom because the control register stays 0 through that part causing the write to be skipped.