### PR TITLE
Flash ROM settle time fix

### DIFF
--- a/src/flash.cpp
+++ b/src/flash.cpp
@@ -65,7 +65,7 @@ void flash_write_init(firestarter_handle_t* handle) {
 
     if (is_flag_set(FLAG_CAN_ERASE) && !is_flag_set(FLAG_SKIP_ERASE)) {
         internal_erase(handle);
-        delay(101);
+        delay(105); //Old chips, worst case assumed to 5% longer to erase 
     }
     else {
         debug("Skipping erase of memory");

--- a/src/uno_rurp_shield.cpp
+++ b/src/uno_rurp_shield.cpp
@@ -152,6 +152,7 @@ void rurp_set_data_as_input() {
 
 
 void rurp_write_to_register(uint8_t reg, register_t data) {
+    bool settle = false;
     switch (reg) {
     case LEAST_SIGNIFICANT_BYTE:
         if (lsb_address == (uint8_t)data) {
@@ -169,6 +170,9 @@ void rurp_write_to_register(uint8_t reg, register_t data) {
         if (control_register == data) {
             return;
         }
+        if ((control_register & P1_VPP_ENABLE) > (data & P1_VPP_ENABLE)) {
+            settle = true;
+        }
         control_register = data;
 #ifdef HARDWARE_REVISION
         data = rurp_map_ctrl_reg_to_hardware_revision(data);
@@ -181,6 +185,11 @@ void rurp_write_to_register(uint8_t reg, register_t data) {
     PORTB |= reg;
     // Probably useless - verify later    delayMicroseconds(1); 
     PORTB &= ~(reg);
+    //Take a break here if an address change needs time to settle
+    if (settle)
+    {
+        delayMicroseconds(4);
+    }
 }
 
 register_t rurp_read_from_register(uint8_t reg) {


### PR DESCRIPTION
1) A delay is inserted when A18/Pin 1 is falling. 4uS because the transistor driven pin 1 takes at least 3 uS to fall below 50% VCC.

A rising edge delay isn't needed because there's no transistor delay (driven high through diode).

2)  The flash erase time has been increased to +5% since some chips seem to require longer to return after erasure.